### PR TITLE
Upgraded the nuget package to 2.0 for the matchengine

### DIFF
--- a/testcases/csharp/findCloudletBadSessionCookieRest/findCloudletBadSessionCookieRest/findCloudletBadSessionCookieRest.csproj
+++ b/testcases/csharp/findCloudletBadSessionCookieRest/findCloudletBadSessionCookieRest/findCloudletBadSessionCookieRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/findCloudletFailRest/findCloudletFailRest.sln
+++ b/testcases/csharp/findCloudletFailRest/findCloudletFailRest.sln
@@ -1,7 +1,7 @@
 
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "findCloudletFailRest", "findCloudletFailRest\findCloudletFailRest.csproj", "{2C72983D-DB4E-46E7-A5B5-32A7D144CFE1}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "findCloudletFailRest", "findCloudletFailRest\findCloudletFailRest.csproj", "{229A15FE-934D-40E7-970F-D3CC12D6F683}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -9,9 +9,9 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2C72983D-DB4E-46E7-A5B5-32A7D144CFE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2C72983D-DB4E-46E7-A5B5-32A7D144CFE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2C72983D-DB4E-46E7-A5B5-32A7D144CFE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2C72983D-DB4E-46E7-A5B5-32A7D144CFE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{229A15FE-934D-40E7-970F-D3CC12D6F683}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{229A15FE-934D-40E7-970F-D3CC12D6F683}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{229A15FE-934D-40E7-970F-D3CC12D6F683}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{229A15FE-934D-40E7-970F-D3CC12D6F683}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/testcases/csharp/findCloudletFailRest/findCloudletFailRest/findCloudletFailRest.csproj
+++ b/testcases/csharp/findCloudletFailRest/findCloudletFailRest/findCloudletFailRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/findCloudletMCC_MNC_Rest/findCloudletMCC_MNC_Rest/findCloudletMCC_MNC_Rest.csproj
+++ b/testcases/csharp/findCloudletMCC_MNC_Rest/findCloudletMCC_MNC_Rest/findCloudletMCC_MNC_Rest.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/findCloudletNoCarrierRest/findCloudletNoCarrierRest/findCloudletNoCarrierRest.csproj
+++ b/testcases/csharp/findCloudletNoCarrierRest/findCloudletNoCarrierRest/findCloudletNoCarrierRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/findCloudletNoLocationRest/findCloudletNoLocationRest/findCloudletNoLocationRest.csproj
+++ b/testcases/csharp/findCloudletNoLocationRest/findCloudletNoLocationRest/findCloudletNoLocationRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/findCloudletNoSessionCookieRest/findCloudletNoSessionCookieRest/findCloudletNoSessionCookieRest.csproj
+++ b/testcases/csharp/findCloudletNoSessionCookieRest/findCloudletNoSessionCookieRest/findCloudletNoSessionCookieRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/findCloudletSuccessRest/findCloudletSuccessRest/findCloudletSuccessRest.csproj
+++ b/testcases/csharp/findCloudletSuccessRest/findCloudletSuccessRest/findCloudletSuccessRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/getConnectionsRest/getConnectionsRest/Program.cs
+++ b/testcases/csharp/getConnectionsRest/getConnectionsRest/Program.cs
@@ -46,8 +46,8 @@ namespace RestSample
         static string tokenServerURI = "http://mexdemo.tok.mobiledgex.net:9999/its?followURL=https://dme.mobiledgex.net/verifyLoc";
         static string carrierName = "TDG";
         static string orgName = "MobiledgeX";
-        static string appName = "automation_api_app";
-        static string appVers = "6.0";
+        static string appName = "automation-api-app";
+        static string appVers = "1.0";
         static string host = "eu-qa.dme.mobiledgex.net";
         //static string carrierName = "TDG";
         //static string devName = "MobiledgeX";

--- a/testcases/csharp/getConnectionsRest/getConnectionsRest/getConnectionsRest.csproj
+++ b/testcases/csharp/getConnectionsRest/getConnectionsRest/getConnectionsRest.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/registerClientRest/registerClientRest/registerClientRest.csproj
+++ b/testcases/csharp/registerClientRest/registerClientRest/registerClientRest.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>

--- a/testcases/csharp/registerClientWithAuthRest/registerClientWithAuthRest/registerClientWithAuthRest.csproj
+++ b/testcases/csharp/registerClientWithAuthRest/registerClientWithAuthRest/registerClientWithAuthRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/registerClientWithAuthWrongAppRest/registerClientWithAuthWrongAppRest/registerClientWithAuthWrongAppRest.csproj
+++ b/testcases/csharp/registerClientWithAuthWrongAppRest/registerClientWithAuthWrongAppRest/registerClientWithAuthWrongAppRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/registerClientWithAuthWrongAppVerRest/registerClientWithAuthWrongAppVerRest/registerClientWithAuthWrongAppVerRest.csproj
+++ b/testcases/csharp/registerClientWithAuthWrongAppVerRest/registerClientWithAuthWrongAppVerRest/registerClientWithAuthWrongAppVerRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/registerClientWithAuthWrongDevRest/registerClientWithAuthWrongDevRest/registerClientWithAuthWrongDevRest.csproj
+++ b/testcases/csharp/registerClientWithAuthWrongDevRest/registerClientWithAuthWrongDevRest/registerClientWithAuthWrongDevRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/registerClientWrongAppRest/registerClientWrongAppRest/registerClientWrongAppRest.csproj
+++ b/testcases/csharp/registerClientWrongAppRest/registerClientWrongAppRest/registerClientWrongAppRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/registerClientWrongAppVerRest/registerClientWrongAppVerRest/registerClientWrongAppVerRest.csproj
+++ b/testcases/csharp/registerClientWrongAppVerRest/registerClientWrongAppVerRest/registerClientWrongAppVerRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/registerClientWrongDevNameRest/registerClientWrongDevNameRest/registerClientWrongDevNameRest.csproj
+++ b/testcases/csharp/registerClientWrongDevNameRest/registerClientWrongDevNameRest/registerClientWrongDevNameRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocation100KMRest/verifyLocation100KMRest/verifyLocation100KMRest.csproj
+++ b/testcases/csharp/verifyLocation100KMRest/verifyLocation100KMRest/verifyLocation100KMRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocation10KMRest/verifyLocation10KMRest/verifyLocation10KMRest.csproj
+++ b/testcases/csharp/verifyLocation10KMRest/verifyLocation10KMRest/verifyLocation10KMRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocationBadCarrierRest/verifyLocationBadCarrierRest/verifyLocationBadCarrierRest.csproj
+++ b/testcases/csharp/verifyLocationBadCarrierRest/verifyLocationBadCarrierRest/verifyLocationBadCarrierRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocationBadCookieRest/verifyLocationBadCookieRest/verifyLocationBadCookieRest.csproj
+++ b/testcases/csharp/verifyLocationBadCookieRest/verifyLocationBadCookieRest/verifyLocationBadCookieRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocationMisMatchOtherCountryRest/verifyLocationMisMatchOtherCountryRest/verifyLocationMisMatchOtherCountryRest.csproj
+++ b/testcases/csharp/verifyLocationMisMatchOtherCountryRest/verifyLocationMisMatchOtherCountryRest/verifyLocationMisMatchOtherCountryRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocationMisMatchSameCountryRest/verifyLocationMisMatchSameCountryRest/verifyLocationMisMatchSameCountryRest.csproj
+++ b/testcases/csharp/verifyLocationMisMatchSameCountryRest/verifyLocationMisMatchSameCountryRest/verifyLocationMisMatchSameCountryRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocationRest/verifyLocationRest/verifyLocationRest.csproj
+++ b/testcases/csharp/verifyLocationRest/verifyLocationRest/verifyLocationRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocationRoamingCountryMatchRest/verifyLocationRoamingCountryMatchRest/verifyLocationRoamingCountryMatchRest.csproj
+++ b/testcases/csharp/verifyLocationRoamingCountryMatchRest/verifyLocationRoamingCountryMatchRest/verifyLocationRoamingCountryMatchRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/verifyLocationRoamingCountryMisMatchRest/verifyLocationRoamingCountryMisMatchRest/verifyLocationRoamingCountryMisMatchRest.csproj
+++ b/testcases/csharp/verifyLocationRoamingCountryMisMatchRest/verifyLocationRoamingCountryMisMatchRest/verifyLocationRoamingCountryMisMatchRest.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="1.5.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="2.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
	modified:   testcases/csharp/findCloudletBadSessionCookieRest/findCloudletBadSessionCookieRest/findCloudletBadSessionCookieRest.csproj
	modified:   testcases/csharp/findCloudletFailRest/findCloudletFailRest.sln
	modified:   testcases/csharp/findCloudletFailRest/findCloudletFailRest/findCloudletFailRest.csproj
	modified:   testcases/csharp/findCloudletMCC_MNC_Rest/findCloudletMCC_MNC_Rest/findCloudletMCC_MNC_Rest.csproj
	modified:   testcases/csharp/findCloudletNoCarrierRest/findCloudletNoCarrierRest/findCloudletNoCarrierRest.csproj
	modified:   testcases/csharp/findCloudletNoLocationRest/findCloudletNoLocationRest/findCloudletNoLocationRest.csproj
	modified:   testcases/csharp/findCloudletNoSessionCookieRest/findCloudletNoSessionCookieRest/findCloudletNoSessionCookieRest.csproj
	modified:   testcases/csharp/findCloudletSuccessRest/findCloudletSuccessRest/findCloudletSuccessRest.csproj
	modified:   testcases/csharp/getConnectionsRest/getConnectionsRest/Program.cs
	modified:   testcases/csharp/getConnectionsRest/getConnectionsRest/getConnectionsRest.csproj
	modified:   testcases/csharp/registerClientRest/registerClientRest/registerClientRest.csproj
	modified:   testcases/csharp/registerClientWithAuthRest/registerClientWithAuthRest/registerClientWithAuthRest.csproj
	modified:   testcases/csharp/registerClientWithAuthWrongAppRest/registerClientWithAuthWrongAppRest/registerClientWithAuthWrongAppRest.csproj
	modified:   testcases/csharp/registerClientWithAuthWrongAppVerRest/registerClientWithAuthWrongAppVerRest/registerClientWithAuthWrongAppVerRest.csproj
	modified:   testcases/csharp/registerClientWithAuthWrongDevRest/registerClientWithAuthWrongDevRest/registerClientWithAuthWrongDevRest.csproj
	modified:   testcases/csharp/registerClientWrongAppRest/registerClientWrongAppRest/registerClientWrongAppRest.csproj
	modified:   testcases/csharp/registerClientWrongAppVerRest/registerClientWrongAppVerRest/registerClientWrongAppVerRest.csproj
	modified:   testcases/csharp/registerClientWrongDevNameRest/registerClientWrongDevNameRest/registerClientWrongDevNameRest.csproj
	modified:   testcases/csharp/verifyLocation100KMRest/verifyLocation100KMRest/verifyLocation100KMRest.csproj
	modified:   testcases/csharp/verifyLocation10KMRest/verifyLocation10KMRest/verifyLocation10KMRest.csproj
	modified:   testcases/csharp/verifyLocationBadCarrierRest/verifyLocationBadCarrierRest/verifyLocationBadCarrierRest.csproj
	modified:   testcases/csharp/verifyLocationBadCookieRest/verifyLocationBadCookieRest/verifyLocationBadCookieRest.csproj
	modified:   testcases/csharp/verifyLocationMisMatchOtherCountryRest/verifyLocationMisMatchOtherCountryRest/verifyLocationMisMatchOtherCountryRest.csproj
	modified:   testcases/csharp/verifyLocationMisMatchSameCountryRest/verifyLocationMisMatchSameCountryRest/verifyLocationMisMatchSameCountryRest.csproj
	modified:   testcases/csharp/verifyLocationRest/verifyLocationRest/verifyLocationRest.csproj
	modified:   testcases/csharp/verifyLocationRoamingCountryMatchRest/verifyLocationRoamingCountryMatchRest/verifyLocationRoamingCountryMatchRest.csproj
	modified:   testcases/csharp/verifyLocationRoamingCountryMisMatchRest/verifyLocationRoamingCountryMisMatchRest/verifyLocationRoamingCountryMisMatchRest.csproj