### PR TITLE
updated testcases for controller test failures

### DIFF
--- a/testcases/controller/app/createApp_docker_compose.robot
+++ b/testcases/controller/app/createApp_docker_compose.robot
@@ -38,13 +38,15 @@ CreateApp - User shall be able to create an app with docker compose and no acces
     Should Be Equal As Numbers  ${app['data']['image_type']}           1  #docker
     Should Contain              ${app['data']['deployment_manifest']}  image
 
-CreateApp - User shall not be able to create an app with docker compose and access_type=loadbalancer
-    [Documentation]
-    ...  create app with docker compose access_type=loadbalancer
-    ...  verify error is received 
-
+# ECQ-1996
+# removed test since this supported now
+#CreateApp - User shall not be able to create an app with docker compose and access_type=loadbalancer
+#    [Documentation]
+#    ...  create app with docker compose access_type=loadbalancer
+#    ...  verify error is received 
+#
 #   ${error}=  Run Keyword and Expect Error  *  Create App  region=${region}  access_ports=tcp:2015,tcp:2016,udp:2015,udp:2016  deployment_manifest=${docker_compose_url}  image_type=ImageTypeDocker  deployment=docker  developer_org_name=mobiledgex  app_version=1.0   access_type=loadbalancer
-
+#
 #   Should Contain  ${error}  code=400
 #   Should Contain  ${error}  "message":"ACCESS_TYPE_LOAD_BALANCER not supported for docker deployment type: docker-compose" 
 

--- a/testcases/controller/app/test_appAdd_defaultFlavorEmpty.py
+++ b/testcases/controller/app/test_appAdd_defaultFlavorEmpty.py
@@ -48,139 +48,147 @@ class tc(unittest.TestCase):
 #                                                  #developer_email=developer_email)
 #        self.controller.create_developer(self.developer.developer) 
 
-    def test_CreateAppDefaultFlavorEmpty_Docker(self):
-        # [Documentation] App - User shall be not be able to create app with empty defaultflavor and type Docker
-        # ... create an app with empty default flavor and type Docker
-        # ... verify 'Specified flavor not found' is received 
+    # removed with EDGECLOUD-3103
+    # ECQ-798
+#    def test_CreateAppDefaultFlavorEmpty_Docker(self):
+#        # [Documentation] App - User shall be not be able to create app with empty defaultflavor and type Docker
+#        # ... create an app with empty default flavor and type Docker
+#        # ... verify 'Specified flavor not found' is received 
+#
+#        # print the existing apps 
+#        app_pre = self.controller.show_apps()
+#
+#        # create the app with no parms
+#        error = None
+#        app = mex_controller.App(image_type='ImageTypeDocker',
+#                                 app_name=app_name,
+#                                 access_ports=access_ports,
+#                                 app_version=app_version,
+#                                 cluster_name='dummyCluster',
+#                                 developer_org_name=developer_name,
+#                                 default_flavor_name='')
+#        try:
+#            resp = self.controller.create_app(app.app)
+#        except grpc.RpcError as e:
+#            logging.info('got exception ' + str(e))
+#            error = e
+#
+#        # print the cluster instances after error
+#        app_post = self.controller.show_apps()
+#
+#        expect_equal(error.code(), grpc.StatusCode.UNKNOWN, 'status code')
+#        #expect_equal(error.details(), 'Specified default flavor not found', 'error details')
+#        expect_equal(error.details(), 'Flavor key {} not found', 'error details')
+#        #expect_equal(len(app_pre), len(app_post), 'same number of apps')
+#        assert_expectations()
+#   
+    # removed with EDGECLOUD-3103 
+    # ECQ-799
+#    def test_CreateAppDefaultFlavorEmpty_QCOW(self):
+#        # [Documentation] App - User shall be not be able to create app with empty defaultflavor and type QCOW
+#        # ... create an app with empty default flavor and type QCOW
+#        # ... verify 'Specified flavor not found' is received
+#
+#        # print the existing apps
+#        app_pre = self.controller.show_apps()
+#
+#        # create the app with no parms
+#        error = None
+#        app = mex_controller.App(image_type='ImageTypeQCOW',
+#                                 image_path=qcow_image,
+#                                 app_name=app_name,
+#                                 access_ports=access_ports,
+#                                 app_version=app_version,
+#                                 cluster_name='dummyCluster',
+#                                 developer_org_name=developer_name,
+#                                 default_flavor_name='')
+#        try:
+#            resp = self.controller.create_app(app.app)
+#        except grpc.RpcError as e:
+#            logger.info('got exception ' + str(e))
+#            error = e
+#
+#        # print the cluster instances after error
+#        app_post = self.controller.show_apps()
+#
+#        expect_equal(error.code(), grpc.StatusCode.UNKNOWN, 'status code')
+#        #expect_equal(error.details(), 'Specified default flavor not found', 'error details')
+#        expect_equal(error.details(), 'Flavor key {} not found', 'error details')
+#        #expect_equal(len(app_pre), len(app_post), 'same number of apps')
+#        assert_expectations()
 
-        # print the existing apps 
-        app_pre = self.controller.show_apps()
+# removed with EDGECLOUD-3103
+#    ECQ-800
+#    def test_CreateAppDefaultFlavorNotExist_Docker(self):
+#        # [Documentation] App - User shall be not be able to create app with no defaultflavor and type Docker
+#        # ... create an app with no default flavor and type Docker
+#        # ... verify 'Specified flavor not found' is received
+#
+#        # print the existing apps
+#        app_pre = self.controller.show_apps()
+#
+#        # create the app with no parms
+#        error = None
+#        app = mex_controller.App(image_type='ImageTypeDocker',
+#                                 app_name=app_name,
+#                                 access_ports=access_ports,
+#                                 image_path=docker,
+#                                 app_version=app_version,
+#                                 cluster_name='dummyCluster',
+#                                 developer_org_name=developer_name,
+#                                 use_defaults=False
+#                                 )
+#        try:
+#            resp = self.controller.create_app(app.app)
+#        except grpc.RpcError as e:
+#            logger.info('got exception ' + str(e))
+#            error = e
+#
+#        # print the cluster instances after error
+#        app_post = self.controller.show_apps()
+#
+#        expect_equal(error.code(), grpc.StatusCode.UNKNOWN, 'status code')
+#        #expect_equal(error.details(), 'Specified default flavor not found', 'error details')
+#        expect_equal(error.details(), 'Flavor key {} not found', 'error details')
+#        #expect_equal(len(app_pre), len(app_post), 'same number of apps')
+#        assert_expectations()
 
-        # create the app with no parms
-        error = None
-        app = mex_controller.App(image_type='ImageTypeDocker',
-                                 app_name=app_name,
-                                 access_ports=access_ports,
-                                 app_version=app_version,
-                                 cluster_name='dummyCluster',
-                                 developer_org_name=developer_name,
-                                 default_flavor_name='')
-        try:
-            resp = self.controller.create_app(app.app)
-        except grpc.RpcError as e:
-            logging.info('got exception ' + str(e))
-            error = e
-
-        # print the cluster instances after error
-        app_post = self.controller.show_apps()
-
-        expect_equal(error.code(), grpc.StatusCode.UNKNOWN, 'status code')
-        #expect_equal(error.details(), 'Specified default flavor not found', 'error details')
-        expect_equal(error.details(), 'Flavor key {} not found', 'error details')
-        #expect_equal(len(app_pre), len(app_post), 'same number of apps')
-        assert_expectations()
-
-    def test_CreateAppDefaultFlavorEmpty_QCOW(self):
-        # [Documentation] App - User shall be not be able to create app with empty defaultflavor and type QCOW
-        # ... create an app with empty default flavor and type QCOW
-        # ... verify 'Specified flavor not found' is received
-
-        # print the existing apps
-        app_pre = self.controller.show_apps()
-
-        # create the app with no parms
-        error = None
-        app = mex_controller.App(image_type='ImageTypeQCOW',
-                                 image_path=qcow_image,
-                                 app_name=app_name,
-                                 access_ports=access_ports,
-                                 app_version=app_version,
-                                 cluster_name='dummyCluster',
-                                 developer_org_name=developer_name,
-                                 default_flavor_name='')
-        try:
-            resp = self.controller.create_app(app.app)
-        except grpc.RpcError as e:
-            logger.info('got exception ' + str(e))
-            error = e
-
-        # print the cluster instances after error
-        app_post = self.controller.show_apps()
-
-        expect_equal(error.code(), grpc.StatusCode.UNKNOWN, 'status code')
-        #expect_equal(error.details(), 'Specified default flavor not found', 'error details')
-        expect_equal(error.details(), 'Flavor key {} not found', 'error details')
-        #expect_equal(len(app_pre), len(app_post), 'same number of apps')
-        assert_expectations()
-
-    def test_CreateAppDefaultFlavorNotExist_Docker(self):
-        # [Documentation] App - User shall be not be able to create app with no defaultflavor and type Docker
-        # ... create an app with no default flavor and type Docker
-        # ... verify 'Specified flavor not found' is received
-
-        # print the existing apps
-        app_pre = self.controller.show_apps()
-
-        # create the app with no parms
-        error = None
-        app = mex_controller.App(image_type='ImageTypeDocker',
-                                 app_name=app_name,
-                                 access_ports=access_ports,
-                                 image_path=docker,
-                                 app_version=app_version,
-                                 cluster_name='dummyCluster',
-                                 developer_org_name=developer_name,
-                                 use_defaults=False
-                                 )
-        try:
-            resp = self.controller.create_app(app.app)
-        except grpc.RpcError as e:
-            logger.info('got exception ' + str(e))
-            error = e
-
-        # print the cluster instances after error
-        app_post = self.controller.show_apps()
-
-        expect_equal(error.code(), grpc.StatusCode.UNKNOWN, 'status code')
-        #expect_equal(error.details(), 'Specified default flavor not found', 'error details')
-        expect_equal(error.details(), 'Flavor key {} not found', 'error details')
-        #expect_equal(len(app_pre), len(app_post), 'same number of apps')
-        assert_expectations()
-
-    def test_CreateAppDefaultFlavorNotExist_QCOW(self):
-        # [Documentation] App - User shall be not be able to create app with empty defaultflavor and type QCOW
-        # ... create an app with empty default flavor and type QCOW
-        # ... verify 'Specified flavor not found' is received
-
-        # print the existing apps
-        app_pre = self.controller.show_apps()
-
-        # create the app with no parms
-        error = None
-        app = mex_controller.App(image_type='ImageTypeQCOW',
-                                 image_path=qcow_image,
-                                 app_name=app_name,
-                                 access_ports=access_ports,
-                                 app_version=app_version,
-                                 cluster_name='dummyCluster',
-                                 developer_org_name=developer_name,
-                                 #image_path='imagepath#md5:12345678901234567890123456789012',
-                                 use_defaults=False
-                                 )
-        try:
-            resp = self.controller.create_app(app.app)
-        except grpc.RpcError as e:
-            logger.info('got exception ' + str(e))
-            error = e
-
-        # print the cluster instances after error
-        app_post = self.controller.show_apps()
-
-        expect_equal(error.code(), grpc.StatusCode.UNKNOWN, 'status code')
-        #expect_equal(error.details(), 'Specified default flavor not found', 'error details')
-        expect_equal(error.details(), 'Flavor key {} not found', 'error details')
-        #expect_equal(len(app_pre), len(app_post), 'same number of apps')
-        assert_expectations()
+# removed with EDGECLOUD-3103
+#   ECQ-801
+#    def test_CreateAppDefaultFlavorNotExist_QCOW(self):
+#        # [Documentation] App - User shall be not be able to create app with empty defaultflavor and type QCOW
+#        # ... create an app with empty default flavor and type QCOW
+#        # ... verify 'Specified flavor not found' is received
+#
+#        # print the existing apps
+#        app_pre = self.controller.show_apps()
+#
+#        # create the app with no parms
+#        error = None
+#        app = mex_controller.App(image_type='ImageTypeQCOW',
+#                                 image_path=qcow_image,
+#                                 app_name=app_name,
+#                                 access_ports=access_ports,
+#                                 app_version=app_version,
+#                                 cluster_name='dummyCluster',
+#                                 developer_org_name=developer_name,
+#                                 #image_path='imagepath#md5:12345678901234567890123456789012',
+#                                 use_defaults=False
+#                                 )
+#        try:
+#            resp = self.controller.create_app(app.app)
+#        except grpc.RpcError as e:
+#            logger.info('got exception ' + str(e))
+#            error = e
+#
+#        # print the cluster instances after error
+#        app_post = self.controller.show_apps()
+#
+#        expect_equal(error.code(), grpc.StatusCode.UNKNOWN, 'status code')
+#        #expect_equal(error.details(), 'Specified default flavor not found', 'error details')
+#        expect_equal(error.details(), 'Flavor key {} not found', 'error details')
+#        #expect_equal(len(app_pre), len(app_post), 'same number of apps')
+#        assert_expectations()
 
 #    @classmethod
 #    def tearDownClass(self):

--- a/testcases/controller/cluster/clusterInstAdd_azure_fail.robot
+++ b/testcases/controller/cluster/clusterInstAdd_azure_fail.robot
@@ -11,6 +11,7 @@ ${operator_name_azure}  azure
 ${cloudlet_name_azure}  automationCentralCloudlet 
 
 *** Test Cases ***
+# ECQ-1596
 CreateClusterInst - create a clusterinst with nummasters=1 numnodes=0 for azure should fail
     [Documentation]
     ...  create a cluster instance with nummasters=1 numnodes-0 for azure 
@@ -18,12 +19,15 @@ CreateClusterInst - create a clusterinst with nummasters=1 numnodes=0 for azure 
 
     ${error}=  Run Keyword and Expect Error  *  Create Cluster Instance  region=US  operator_org_name=${operator_name_azure}  cloudlet_name=${cloudlet_name_azure}  number_masters=1  number_nodes=0 
 
-    ${code}=  Response Status Code
-    ${body}=  Response Body
+    Should Be Equal  ${error}  ('code=400', 'error={"message":"NumNodes cannot be 0 for Azure or GCP"}')
 
-    Should Be Equal As Numbers  ${code}  400 
-    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"} 
+#    ${code}=  Response Status Code
+#    ${body}=  Response Body
+#
+#    Should Be Equal As Numbers  ${code}  400 
+#    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"} 
 
+# ECQ-1597
 CreateClusterInst - create a clusterinst with nummasters=0 numnodes=0 for azure should fail
     [Documentation]
     ...  create a cluster instance with nummasters=0 numnodes-0 for azure
@@ -31,12 +35,15 @@ CreateClusterInst - create a clusterinst with nummasters=0 numnodes=0 for azure 
 
     ${error}=  Run Keyword and Expect Error  *  Create Cluster Instance  region=US  operator_org_name=${operator_name_azure}  cloudlet_name=${cloudlet_name_azure}  number_masters=0  number_nodes=0
 
-    ${code}=  Response Status Code
-    ${body}=  Response Body
+    Should Be Equal  ${error}  ('code=400', 'error={"message":"NumNodes cannot be 0 for Azure or GCP"}')
 
-    Should Be Equal As Numbers  ${code}  400
-    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"}
+#    ${code}=  Response Status Code
+#    ${body}=  Response Body
 
+#    Should Be Equal As Numbers  ${code}  400
+#    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"}
+
+# ECQ-1598
 CreateClusterInst - create a clusterinst with numnodes=0 for azure should fail
     [Documentation]
     ...  create a cluster instance with numnodes=0 for azure
@@ -48,9 +55,10 @@ CreateClusterInst - create a clusterinst with numnodes=0 for azure should fail
 
     ${error}=  Run Keyword and Expect Error  *  Create Cluster Instance  region=US  cluster_name=${cluster}  developer_org_name=${developer}  operator_org_name=${operator_name_azure}  cloudlet_name=${cloudlet_name_azure}  number_nodes=0  token=${token}  use_defaults=${False}
 
-    ${code}=  Response Status Code
-    ${body}=  Response Body
+    Should Be Equal  ${error}  ('code=400', 'error={"message":"NumNodes cannot be 0 for Azure or GCP"}')
 
-    Should Be Equal As Numbers  ${code}  400
-    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"}
-
+#    ${code}=  Response Status Code
+#    ${body}=  Response Body
+#
+#    Should Be Equal As Numbers  ${code}  400
+#    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"}

--- a/testcases/controller/cluster/clusterInstAdd_gcp_fail.robot
+++ b/testcases/controller/cluster/clusterInstAdd_gcp_fail.robot
@@ -11,6 +11,7 @@ ${operator_name_gcp}  gcp
 ${cloudlet_name_gcp_fake}  automationCentralCloudlet 
 
 *** Test Cases ***
+# ECQ-1593
 CreateClusterInst - create a clusterinst with nummasters=1 numnodes=0 for gcp should fail
     [Documentation]
     ...  create a cluster instance with nummasters=1 numnodes-0 for gcp 
@@ -18,12 +19,15 @@ CreateClusterInst - create a clusterinst with nummasters=1 numnodes=0 for gcp sh
 
     ${error}=  Run Keyword and Expect Error  *  Create Cluster Instance  region=US  operator_org_name=${operator_name_gcp}  cloudlet_name=${cloudlet_name_gcp}  number_masters=1  number_nodes=0 
 
-    ${code}=  Response Status Code
-    ${body}=  Response Body
+    Should Be Equal  ${error}  ('code=400', 'error={"message":"NumNodes cannot be 0 for Azure or GCP"}')
 
-    Should Be Equal As Numbers  ${code}  400 
-    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"} 
+#    ${code}=  Response Status Code
+#    ${body}=  Response Body
+#
+#    Should Be Equal As Numbers  ${code}  400 
+#    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"} 
 
+# ECQ-1594
 CreateClusterInst - create a clusterinst with nummasters=0 numnodes=0 for gcp should fail
     [Documentation]
     ...  create a cluster instance with nummasters=0 numnodes-0 for gcp 
@@ -31,12 +35,15 @@ CreateClusterInst - create a clusterinst with nummasters=0 numnodes=0 for gcp sh
 
     ${error}=  Run Keyword and Expect Error  *  Create Cluster Instance  region=US  operator_org_name=${operator_name_gcp}  cloudlet_name=${cloudlet_name_gcp}  number_masters=0  number_nodes=0
 
-    ${code}=  Response Status Code
-    ${body}=  Response Body
+    Should Be Equal  ${error}  ('code=400', 'error={"message":"NumNodes cannot be 0 for Azure or GCP"}')
 
-    Should Be Equal As Numbers  ${code}  400
-    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"}
+    #${code}=  Response Status Code
+    #${body}=  Response Body
 
+    #Should Be Equal As Numbers  ${code}  400
+    #Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"}
+
+# ECQ-1595
 CreateClusterInst - create a clusterinst with numnodes=0 for gcp should fail
     [Documentation]
     ...  create a cluster instance with numnodes=0 for gcp 
@@ -48,11 +55,13 @@ CreateClusterInst - create a clusterinst with numnodes=0 for gcp should fail
 
     ${error}=  Run Keyword and Expect Error  *  Create Cluster Instance  region=US  cluster_name=${cluster}  developer_org_name=${developer}  operator_org_name=${operator_name_gcp}  cloudlet_name=${cloudlet_name_gcp}  number_nodes=0  token=${token}  use_defaults=${False}
 
-    ${code}=  Response Status Code
-    ${body}=  Response Body
+    Should Be Equal  ${error}  ('code=400', 'error={"message":"NumNodes cannot be 0 for Azure or GCP"}')
 
-    Should Be Equal As Numbers  ${code}  400
-    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"}
+#    ${code}=  Response Status Code
+#    ${body}=  Response Body
+#
+#    Should Be Equal As Numbers  ${code}  400
+#    Should Be Equal             ${body}  {"message":"NumNodes cannot be 0 for Azure or GCP"}
 
 *** Keywords ***
 Setup

--- a/testcases/controller/privacypolicy/createPrivacyPolicy_fail.robot
+++ b/testcases/controller/privacypolicy/createPrivacyPolicy_fail.robot
@@ -201,8 +201,9 @@ CreatePrivacyPolicy - create with duplicate policy shall return error
    ${policyname}=  Get Default Privacy Policy Name
    ${developer}=  Get Default Developer Name
 
-   Run Keyword and Expect Error  ('code=400', 'error={"message":"key {\\\\"organization\\\\":\\\\"${developer}\\\\",\\\\"name\\\\":\\\\"${policyname}\\\\"} already exists"}')  Create Privacy Policy  region=${region}  token=${token}  rule_list=${rulelist}
+   Run Keyword and Expect Error  ('code=400', 'error={"message":"Key {\\\\"organization\\\\":\\\\"${developer}\\\\",\\\\"name\\\\":\\\\"${policyname}\\\\"} already exists"}')  Create Privacy Policy  region=${region}  token=${token}  rule_list=${rulelist}
 
+# ECQ-1820
 CreatePrivacyPolicy - CreateClusterInst with k8s shared shall return error
    [Documentation]
    ...  send CreatePrivacyPolicy with k8s shared 
@@ -211,6 +212,7 @@ CreatePrivacyPolicy - CreateClusterInst with k8s shared shall return error
    &{rule1}=  Create Dictionary  protocol=udp  port_range_minimum=1001  port_range_maximum=2001  remote_cidr=3.1.1.1/1
    @{rulelist}=  Create List  ${rule1}
 
+   Create Flavor  region=${region}
    ${policy_return}=  Create Privacy Policy  region=${region}  rule_list=${rulelist}
 
    ${error}=  Run Keyword and Expect Error  *  Create Cluster Instance  region=${region}  cloudlet_name=${cloudlet_name_fake}  operator_org_name=${operator_name_fake}  deployment=kubernetes  ip_access=IpAccessShared  number_masters=1  number_nodes=1  privacy_policy=${policy_return['data']['key']['name']}

--- a/testcases/controller/privacypolicy/updatePrivacyPolicy.robot
+++ b/testcases/controller/privacypolicy/updatePrivacyPolicy.robot
@@ -12,6 +12,7 @@ ${region}=  US
 ${developer}=  mobiledgex
 
 *** Test Cases ***
+# ECQ-1842
 UpdatePrivacyPolicy - shall be able to add rules
    [Documentation]
    ...  send CreatePrivacyPolicy without rules
@@ -20,9 +21,9 @@ UpdatePrivacyPolicy - shall be able to add rules
 
    ${policy_return}=  Create Privacy Policy  region=${region}
 
-   Should Be Equal  ${policy_return['data']['key']['name']}                                ${policy_name}
-   Should Be Equal  ${policy_return['data']['key']['organization']}                           ${developer_name}
-   Should Not Contain  ${policy_return['data']  outbound_security_rules
+   Should Be Equal  ${policy_return['data']['key']['name']}              ${policy_name}
+   Should Be Equal  ${policy_return['data']['key']['organization']}      ${developer_name}
+   Should Be Equal  ${policy_return['data']['outbound_security_rules']}  ${None}
 
    &{rule1}=  Create Dictionary  protocol=tcp  port_range_minimum=5  port_range_maximum=6  remote_cidr=1.1.1.1/1
    &{rule2}=  Create Dictionary  protocol=icmp  remote_cidr=2.1.1.1/1

--- a/testcases/controller/privacypolicy/updatePrivacyPolicy_fail.robot
+++ b/testcases/controller/privacypolicy/updatePrivacyPolicy_fail.robot
@@ -20,6 +20,7 @@ ${cloudlet_name_gcp}=  automationGcpCentralCloudlet
 
 
 *** Test Cases ***
+# ECQ-1840
 UpdatePrivacyPolicy - update without region shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy without region
@@ -27,6 +28,7 @@ UpdatePrivacyPolicy - update without region shall return error
 
    Run Keyword and Expect Error  ('code=400', 'error={"message":"no region specified"}')  Update Privacy Policy  token=${token}  use_defaults=${False}
 
+# ECQ-1862
 UpdatePrivacyPolicy - update without token shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy without token
@@ -34,6 +36,7 @@ UpdatePrivacyPolicy - update without token shall return error
 
    Run Keyword and Expect Error  ('code=400', 'error={"message":"no bearer token found"}')  Update Privacy Policy  region=${region}  use_defaults=${False}
 
+# ECQ-1841
 UpdatePrivacyPolicy - update without parms shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy with no parms 
@@ -41,12 +44,13 @@ UpdatePrivacyPolicy - update without parms shall return error
 
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Policy key {} not found"}')  Update Privacy Policy  region=${region}  token=${token}  use_defaults=${False}
 
+# ECQ-1842
 UpdatePrivacyPolicy - update without policy name shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy with no policy name 
    ...  verify error is returned
-   EDGECLOUD-1953 - PrivacyPolicy - update without a policy name returns wrong error
-   Run Keyword and Expect Error  ('code=400', 'error={"message":"Policy key {\\\\"developer\\\\":\\\\"mobiledgex\\\\"} not found"}')  Update Privacy Policy  developer_org_name=mobiledgex  region=${region}  token=${token}  use_defaults=${False}
+   #EDGECLOUD-1953 - PrivacyPolicy - update without a policy name returns wrong error
+   Run Keyword and Expect Error  ('code=400', 'error={"message":"Policy key {\\\\"organization\\\\":\\\\"mobiledgex\\\\"} not found"}')  Update Privacy Policy  developer_org_name=mobiledgex  region=${region}  token=${token}  use_defaults=${False}
 
 UpdatePrivacyPolicy - update with unknown org name shall return error
    [Documentation]
@@ -56,6 +60,7 @@ UpdatePrivacyPolicy - update with unknown org name shall return error
    #Run Keyword and Expect Error  ('code=403', 'error={"message":"code=403, message=Forbidden"}')  Update Privacy Policy  developer_org_name=xxxx  region=${region}  token=${token}  use_defaults=${False}
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Policy key {\\\\"organization\\\\":\\\\"xxxx\\\\"} not found"}')  Update Privacy Policy  developer_org_name=xxxx  region=${region}  token=${token}  use_defaults=${False}
 
+# ECQ-1844
 UpdatePrivacyPolicy - update without developer name shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy with no developer name
@@ -63,6 +68,7 @@ UpdatePrivacyPolicy - update without developer name shall return error
 
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Policy key {\\\\"name\\\\":\\\\"x\\\\"} not found"}')  Update Privacy Policy  policy_name=x  region=${region}  token=${token}  use_defaults=${False}
 
+# ECQ-1845
 UpdatePrivacyPolicy - update without protocol shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy without protocol
@@ -78,6 +84,7 @@ UpdatePrivacyPolicy - update without protocol shall return error
    @{rulelist}=  Create List  ${rule}
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Protocol must be one of: (tcp,udp,icmp)"}')   Update Privacy Policy  region=${region}  rule_list=${rulelist} 
 
+# ECQ-1846
 UpdatePrivacyPolicy - update with invalid CIDR shall return error 
    [Documentation]
    ...  send UpdatePrivacyPolicy with invalid CIDR 
@@ -108,6 +115,7 @@ UpdatePrivacyPolicy - update with invalid CIDR shall return error
    @{rulelist}=  Create List  ${rule}
    Run Keyword and Expect Error  ('code=400', 'error={"message":"invalid CIDR address: "}')  Update Privacy Policy  region=${region}  token=${token}  rule_list=${rulelist} 
 
+# ECQ-1847
 UpdatePrivacyPolicy - update with invalid minport shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy with invalid min port 
@@ -137,6 +145,7 @@ UpdatePrivacyPolicy - update with invalid minport shall return error
    @{rulelist}=  Create List  ${rule}
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Invalid min port range: 65536"}')  Update Privacy Policy  region=${region}  token=${token}  rule_list=${rulelist} 
 
+# ECQ-1848
 UpdatePrivacyPolicy - update with invalid maxport shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy with invalid max port
@@ -158,6 +167,7 @@ UpdatePrivacyPolicy - update with invalid maxport shall return error
    @{rulelist}=  Create List  ${rule}
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Invalid max port range: 65536"}')  Update Privacy Policy  region=${region}  token=${token}  rule_list=${rulelist} 
 
+# ECQ-1849
 UpdatePrivacyPolicy - update with icmp and port range shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy with icmp and port range
@@ -183,6 +193,7 @@ UpdatePrivacyPolicy - update with icmp and port range shall return error
    @{rulelist}=  Create List  ${rule}
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Port range must be empty for icmp"}')  Update Privacy Policy  region=${region}  token=${token}  rule_list=${rulelist} 
 
+# ECQ-1850
 UpdatePrivacyPolicy - update with minport>maxport shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy with minport>maxport
@@ -200,6 +211,7 @@ UpdatePrivacyPolicy - update with minport>maxport shall return error
    @{rulelist}=  Create List  ${rule}
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Min port range: 10 cannot be higher than max: 1"}')  Update Privacy Policy  region=${region}  token=${token}  rule_list=${rulelist}
 
+# ECQ-1851
 UpdatePrivacyPolicy - update with policy not found shall return error
    [Documentation]
    ...  send UpdatePrivacyPolicy with a policy that does not exist 
@@ -213,6 +225,7 @@ UpdatePrivacyPolicy - update with policy not found shall return error
    @{rulelist}=  Create List  ${rule}
    Run Keyword and Expect Error  ('code=400', 'error={"message":"Policy key {\\\\"organization\\\\":\\\\"${dev}\\\\",\\\\"name\\\\":\\\\"${name}\\\\"} not found"}')  Update Privacy Policy  region=${region}  token=${token}  rule_list=${rulelist}
 
+# ECQ-1852
 UpdatePrivacyPolicy - updating a policy in use by a cluster shall return error
    [Documentation]
    ...  create a clusterinst pointing to a privacy policy


### PR DESCRIPTION
	modified:   createApp_docker_compose.robot
	modified:   test_appAdd_defaultFlavorEmpty.py
	modified:   ../cluster/clusterInstAdd_azure_fail.robot
	modified:   ../cluster/clusterInstAdd_gcp_fail.robot
	modified:   ../privacypolicy/createPrivacyPolicy_fail.robot
	modified:   ../privacypolicy/updatePrivacyPolicy.robot
	modified:   ../privacypolicy/updatePrivacyPolicy_fail.robot