### PR TITLE
fix failing dme tests and update mex_rest for cases where resp.conten…

### DIFF
--- a/modules/mex_rest.py
+++ b/modules/mex_rest.py
@@ -28,19 +28,21 @@ class MexRest(WebService) :
             raise Exception("ws did not return a 200 response. responseCode = " + str(self.resp.status_code) + ". ResponseBody=" + str(self.resp.text).rstrip())
 
     def _decode_content(self):
-        logging.debug('content=' + self.resp.content.decode("utf-8"))
-
         try:
+            logging.debug('content=' + self.resp.content.decode("utf-8"))
             self.decoded_data = json.loads(self.resp.content.decode("utf-8"))
         except:
-            datasplit = self.resp.content.decode("utf-8").splitlines()
-            if len(datasplit) == 1:
-                self.decoded_data = self.resp.content.decode("utf-8")
-            else:
-                data_list = []
-                for data in datasplit:
-                    data_list.append(json.loads(data))
-                self.decoded_data = data_list
+            try:
+                datasplit = self.resp.content.decode("utf-8").splitlines()
+                if len(datasplit) == 1:
+                    self.decoded_data = self.resp.content.decode("utf-8")
+                else:
+                    data_list = []
+                    for data in datasplit:
+                        data_list.append(json.loads(data))
+                    self.decoded_data = data_list
+            except:
+                logging.debug('error decoding response content')
 
 #        datasplit = self.resp.content.decode("utf-8").splitlines()
 #        print('*WARN*', 'datasplit',datasplit)

--- a/testcases/dme/cloudlet/getAppOfficialFqdn_fail.robot
+++ b/testcases/dme/cloudlet/getAppOfficialFqdn_fail.robot
@@ -62,6 +62,7 @@ Setup
     Create Flavor
     #Create Cluster	
     #Create Developer            developer_name=${samsung_developer_name}
-    Create App			developer_org_name=${samsung_developer_name}  app_name=${samsung_app_name}  access_ports=tcp:1  official_fqdn=${samsung_uri} 
+    # ignore error since sometimes the samsung app already exists
+    Run Keyword and Ignore Error  Create App			developer_org_name=${samsung_developer_name}  app_name=${samsung_app_name}  access_ports=tcp:1  official_fqdn=${samsung_uri} 
     #Create App Instance         app_name=${samsung_app_name}  developer_name=${samsung_developer_name}  cloudlet_name=${samsung_cloudlet_name}  operator_org_name=${samsung_operator_name}  uri=${samsung_uri}  cluster_instance_name=autocluster
 

--- a/testcases/dme/cloudlet/platformFindCloudlet_fail.robot
+++ b/testcases/dme/cloudlet/platformFindCloudlet_fail.robot
@@ -84,6 +84,7 @@ Setup
     Create Flavor
     #Create Cluster	
     #Create Developer            developer_name=${samsung_developer_name}
-    Create App			developer_org_name=${samsung_developer_name}  app_name=${samsung_app_name}  access_ports=tcp:1  official_fqdn=${samsung_uri} 
+    # ignore error since samsung app sometimes already exists
+    Run Keyword and Ignore Error  Create App			developer_org_name=${samsung_developer_name}  app_name=${samsung_app_name}  access_ports=tcp:1  official_fqdn=${samsung_uri} 
     #Create App Instance         app_name=${samsung_app_name}  developer_name=${samsung_developer_name}  cloudlet_name=${samsung_cloudlet_name}  operator_org_name=${samsung_operator_name}  uri=${samsung_uri}  cluster_instance_name=autocluster
 

--- a/testcases/dme/showDeviceReport/showDeviceReport_Samsung.robot
+++ b/testcases/dme/showDeviceReport/showDeviceReport_Samsung.robot
@@ -373,7 +373,8 @@ Setup
    # ShowDevice  uniqueid=${uniqueid}  
 #ShowDevice  uniqueid=${uniqueid}    
     #ShowDevice  uniqueidtype=${uniqueidtype}
-    Create App  region=${region}  developer_org_name=${samsung_developer_name}  app_name=${samsung_app_name}  access_ports=tcp:1  image_path=docker-qa.mobiledgex.net/samsung/images/server_ping_threaded:6.0
+    # ignore error since sometimes the Samsung app already exists
+    Run Keyword and Ignore Error  Create App  region=${region}  developer_org_name=${samsung_developer_name}  app_name=${samsung_app_name}  access_ports=tcp:1  image_path=docker-qa.mobiledgex.net/samsung/images/server_ping_threaded:6.0
 
 
 {count}  Evaluate  ${count}+1


### PR DESCRIPTION
…t is unreadable

	modified:   mex_rest.py
	modified:   ../testcases/dme/cloudlet/getAppOfficialFqdn_fail.robot
	modified:   ../testcases/dme/cloudlet/platformFindCloudlet_fail.robot
	modified:   ../testcases/dme/showDeviceReport/showDeviceReport_Samsung.robot