### PR TITLE
comment out verification of response for UpdateCloudlet

### DIFF
--- a/modules/mex_master_controller/MexOperation.py
+++ b/modules/mex_master_controller/MexOperation.py
@@ -105,11 +105,11 @@ class MexOperation(MexRest):
                 elif url.endswith('DeleteCloudlet'):
                     if 'Deleted Cloudlet successfully' not in str(self.resp.text):
                         raise Exception('ERROR: Cloudlet not deleted successfully:' + str(self.resp.text))
-                elif url.endswith('UpdateCloudlet'):
-                    if 'Updated Cloudlet successfully' in str(self.resp.text) or 'Upgraded Cloudlet successfully' in str(self.resp.text) or 'Cloudlet updated successfully' in str(self.resp.text):
-                        pass
-                    else:
-                        raise Exception('ERROR: Cloudlet not updated successfully:' + str(self.resp.text))
+                #elif url.endswith('UpdateCloudlet'):
+                #    if 'Updated Cloudlet successfully' in str(self.resp.text) or 'Upgraded Cloudlet successfully' in str(self.resp.text) or 'Cloudlet updated successfully' in str(self.resp.text):
+                #        pass
+                #    else:
+                #        raise Exception('ERROR: Cloudlet not updated successfully:' + str(self.resp.text))
             except Exception as e:
                 logger.info('operation failed:' + str(sys.exc_info()))
                 self.counter_dict[message_type]['req_fail'] += 1


### PR DESCRIPTION
After fix for EDGECLOUD-3771 , there has been a change in the return response for UpdateCloudlet :

angshuman@abhattacharjee-mac ~ % mcctl --addr https://console-qa.mobiledgex.net:443 --skipverify region UpdateCloudlet region=EU cloudlet=testuicloudlet cloudlet-org=TDG maintenancestate=MaintenanceStart
message: Starting AutoProv failover
message: AutoProv failover completed
message: Starting CRM maintenance
message: CRM maintenance started
message: Cloudlet is in maintenance

angshuman@abhattacharjee-mac ~ % mcctl --addr https://console-qa.mobiledgex.net:443 --skipverify region UpdateCloudlet region=EU cloudlet=testuicloudlet cloudlet-org=TDG maintenancestate=NormalOperation
angshuman@abhattacharjee-mac ~ %
