### PR TITLE
fix jenkins crmpool for nonpool tests

### DIFF
--- a/jenkins/execJira_parallel.py
+++ b/jenkins/execJira_parallel.py
@@ -459,6 +459,9 @@ def exec_testcase(z, t):
         var_cmd = ''
         variable_file = ''
         var_override_cmd = ''
+        region = 'noCRMPoolDefined'
+        cloudlet = 'noCRMPoolDefined'
+        operator = 'noCRMPoolDefined'
 
         if 'VariableFile' in os.environ:
             variable_file = os.environ['VariableFile']


### PR DESCRIPTION
	modified:   execJira_parallel.py