### PR TITLE
fix HA tests for configurable testtimeout and fix compose path

### DIFF
--- a/testcases/crm/app/create_appInst_docker_compose_zip.robot
+++ b/testcases/crm/app/create_appInst_docker_compose_zip.robot
@@ -45,7 +45,7 @@ User shall be able to deploy docker compose zip filed from artifactory
     ...  deploy the app to openstack
     ...  verify containers are running 
 
-    ${docker_compose_zip_full}=  Find File  ${docker_compose_zip_path}/${docker_compose_zip}
+    ${docker_compose_zip_full}=  Find File  ${docker_compose_zip}
     ${cluster_name_default}=  Get Default Cluster Name
     ${app_name_default}=  Get Default App Name
 

--- a/testcases/crm/cluster/HA_between_Openstack_VMPool_Docker.robot
+++ b/testcases/crm/cluster/HA_between_Openstack_VMPool_Docker.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     10 minutes
+Test Timeout    ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/HA_between_Openstack_VMPool_k8s.robot
+++ b/testcases/crm/cluster/HA_between_Openstack_VMPool_k8s.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     10 minutes
+Test Timeout    ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/HA_between_Openstack_VSphere_Docker.robot
+++ b/testcases/crm/cluster/HA_between_Openstack_VSphere_Docker.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     10 minutes
+Test Timeout    ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/HA_between_Openstack_Vsphere_K8s.robot
+++ b/testcases/crm/cluster/HA_between_Openstack_Vsphere_K8s.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     10 minutes
+Test Timeout    ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/verify_HA_deleting_cloudlet_from_policy_docker.robot
+++ b/testcases/crm/cluster/verify_HA_deleting_cloudlet_from_policy_docker.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     10 minutes
+Test Timeout   ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/verify_HA_deleting_cloudlet_from_policy_k8s.robot
+++ b/testcases/crm/cluster/verify_HA_deleting_cloudlet_from_policy_k8s.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     15 minutes
+Test Timeout    ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/verify_HA_with_1_min_active_instance_Docker.robot
+++ b/testcases/crm/cluster/verify_HA_with_1_min_active_instance_Docker.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     10 minutes
+Test Timeout    ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/verify_HA_with_1_min_active_instance_k8s.robot
+++ b/testcases/crm/cluster/verify_HA_with_1_min_active_instance_k8s.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     15 minutes
+Test Timeout     ${test_timeout_crm}
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/verify_HA_with_2_min_active_instances_Docker.robot
+++ b/testcases/crm/cluster/verify_HA_with_2_min_active_instances_Docker.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     10 minutes
+Test Timeout    ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup

--- a/testcases/crm/cluster/verify_HA_with_2_min_active_instances_k8s.robot
+++ b/testcases/crm/cluster/verify_HA_with_2_min_active_instances_k8s.robot
@@ -6,7 +6,7 @@ Library         MexDme  dme_address=%{AUTOMATION_DME_ADDRESS}
 Library		    MexMasterController  mc_address=%{AUTOMATION_MC_ADDRESS}  root_cert=%{AUTOMATION_MC_CERT}
 Library         MexApp
 
-Test Timeout     15 minutes
+Test Timeout    ${test_timeout_crm} 
 
 Suite Setup      Setup
 Suite Teardown  Cleanup


### PR DESCRIPTION
	modified:   create_appInst_docker_compose_zip.robot
	modified:   ../cluster/HA_between_Openstack_VMPool_Docker.robot
	modified:   ../cluster/HA_between_Openstack_VMPool_k8s.robot
	modified:   ../cluster/HA_between_Openstack_VSphere_Docker.robot
	modified:   ../cluster/HA_between_Openstack_Vsphere_K8s.robot
	modified:   ../cluster/verify_HA_deleting_cloudlet_from_policy_docker.robot
	modified:   ../cluster/verify_HA_deleting_cloudlet_from_policy_k8s.robot
	modified:   ../cluster/verify_HA_with_1_min_active_instance_Docker.robot
	modified:   ../cluster/verify_HA_with_1_min_active_instance_k8s.robot
	modified:   ../cluster/verify_HA_with_2_min_active_instances_Docker.robot
	modified:   ../cluster/verify_HA_with_2_min_active_instances_k8s.robot