### PR TITLE
Fix load existence check

### DIFF
--- a/jenkins/run_edgecloud.jenkinsfile
+++ b/jenkins/run_edgecloud.jenkinsfile
@@ -144,8 +144,7 @@ node('jenkinsSlave1'){
        stage('Check Load Exists') {
           def s = 'curl -s https://mobiledgex:sandhill@registry.mobiledgex.net:5000/v2/mobiledgex/edge-cloud/tags/list | jq ".tags | index(\\"' + tag + '\\")"'
           def index  = sh(script: s, returnStdout: true);
-	  int indexnum = index as Integer
-          if(indexnum < 1) {
+	  if(index == 'null') {
              println "${s} failed"
              currentBuild.result = 'FAILURE'
           }


### PR DESCRIPTION
The current check for load existence looks for an index value of greater than 0. But 0 is a valid index if the tag is the first in the list.

```
$ curl -s https://mobiledgex:sandhill@registry.mobiledgex.net:5000/v2/mobiledgex/edge-cloud/tags/list
{"name":"mobiledgex/edge-cloud","tags":["2021-08-13","2021-0701-mattw-cli2" ...

$ curl -s https://mobiledgex:sandhill@registry.mobiledgex.net:5000/v2/mobiledgex/edge-cloud/tags/list \
  | jq '.tags | index("2021-08-13")'
0
```

If the tag does not exist, `jq` returns a "null" string:
```
$ curl -s https://mobiledgex:sandhill@registry.mobiledgex.net:5000/v2/mobiledgex/edge-cloud/tags/list \
  | jq '.tags | index("2021-08-13y")'
null
```