### PR TITLE
Changed host override to us dme and updated Nuget package to 3.0.0

### DIFF
--- a/testcases/csharp/getConnectionWorkflowRest/getConnectionWorkflowRest/Program.cs
+++ b/testcases/csharp/getConnectionWorkflowRest/getConnectionWorkflowRest/Program.cs
@@ -92,8 +92,8 @@ namespace RestSample
         // static string fallbackDmeHost = "wifi.dme.mobiledgex.net";
 
         // QA env 
-        static string host = "eu-qa.dme.mobiledgex.net";
-        //static string fallbackDmeHost = "eu-qa.dme.mobiledgex.net";
+        static string host = "us-qa.dme.mobiledgex.net";
+        //static string fallbackDmeHost = "us-qa.dme.mobiledgex.net";
 
         // Production env
         //static string host = "us-mexdemo.dme.mobiledgex.net";

--- a/testcases/csharp/getConnectionWorkflowRest/getConnectionWorkflowRest/getConnectionWorkflowRest.csproj
+++ b/testcases/csharp/getConnectionWorkflowRest/getConnectionWorkflowRest/getConnectionWorkflowRest.csproj
@@ -12,7 +12,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.1" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0-rc2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.2" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/getHTTPConnectionsRest/getHTTPConnectionsRest/Program.cs
+++ b/testcases/csharp/getHTTPConnectionsRest/getHTTPConnectionsRest/Program.cs
@@ -79,8 +79,8 @@ namespace RestSample
         static string orgName = "automation_dev_org";
         static string appName = "automation-sdk-porttest";
         static string appVers = "1.0";
-        static string host = "eu-qa.dme.mobiledgex.net";
-        static string fallbackDmeHost = "eu-qa.dme.mobiledgex.net";
+        static string host = "us-qa.dme.mobiledgex.net";
+        static string fallbackDmeHost = "us-qa.dme.mobiledgex.net";
 
         //Main
         // Production env

--- a/testcases/csharp/getHTTPConnectionsRest/getHTTPConnectionsRest/getHTTPConnectionsRest.csproj
+++ b/testcases/csharp/getHTTPConnectionsRest/getHTTPConnectionsRest/getHTTPConnectionsRest.csproj
@@ -12,6 +12,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0-rc2" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/getTCPConnectionsRest/getTCPConnectionsRest/Program.cs
+++ b/testcases/csharp/getTCPConnectionsRest/getTCPConnectionsRest/Program.cs
@@ -81,8 +81,8 @@ namespace RestSample
         static string orgName = "automation_dev_org";
         static string appName = "automation-sdk-porttest";
         static string appVers = "1.0";
-        static string host = "eu-qa.dme.mobiledgex.net";
-        static string fallbackDmeHost = "eu-qa.dme.mobiledgex.net";
+        static string host = "us-qa.dme.mobiledgex.net";
+        static string fallbackDmeHost = "us-qa.dme.mobiledgex.net";
 
         //Main
         // Production env

--- a/testcases/csharp/getTCPConnectionsRest/getTCPConnectionsRest/getTCPConnectionsRest.csproj
+++ b/testcases/csharp/getTCPConnectionsRest/getTCPConnectionsRest/getTCPConnectionsRest.csproj
@@ -12,6 +12,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0-rc2" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/getTLSConnectionsRest/getTLSConnectionsRest/Program.cs
+++ b/testcases/csharp/getTLSConnectionsRest/getTLSConnectionsRest/Program.cs
@@ -79,8 +79,8 @@ namespace RestSample
         static string orgName = "automation_dev_org";
         static string appName = "automation-sdk-porttest";
         static string appVers = "1.0";
-        static string host = "eu-qa.dme.mobiledgex.net";
-        static string fallbackDmeHost = "eu-qa.dme.mobiledgex.net";
+        static string host = "us-qa.dme.mobiledgex.net";
+        static string fallbackDmeHost = "us-qa.dme.mobiledgex.net";
 
         //Main
         // Production env

--- a/testcases/csharp/getTLSConnectionsRest/getTLSConnectionsRest/getTLSConnectionsRest.csproj
+++ b/testcases/csharp/getTLSConnectionsRest/getTLSConnectionsRest/getTLSConnectionsRest.csproj
@@ -12,7 +12,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.1" />
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0-rc2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.2" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/getUDPConnectionsRest/getUDPConnectionsRest/Program.cs
+++ b/testcases/csharp/getUDPConnectionsRest/getUDPConnectionsRest/Program.cs
@@ -80,8 +80,8 @@ namespace RestSample
         static string orgName = "automation_dev_org";
         static string appName = "automation-sdk-porttest";
         static string appVers = "1.0";
-        static string host = "eu-qa.dme.mobiledgex.net";
-        static string fallbackDmeHost = "eu-qa.dme.mobiledgex.net";
+        static string host = "us-qa.dme.mobiledgex.net";
+        static string fallbackDmeHost = "us-qa.dme.mobiledgex.net";
 
         //Main
         // Production env

--- a/testcases/csharp/getUDPConnectionsRest/getUDPConnectionsRest/getUDPConnectionsRest.csproj
+++ b/testcases/csharp/getUDPConnectionsRest/getUDPConnectionsRest/getUDPConnectionsRest.csproj
@@ -12,6 +12,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0-rc2" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/testcases/csharp/getWEBServerConnectionRest/getWEBServerConnectionRest/Program.cs
+++ b/testcases/csharp/getWEBServerConnectionRest/getWEBServerConnectionRest/Program.cs
@@ -80,8 +80,8 @@ namespace RestSample
         static string orgName = "automation_dev_org";
         static string appName = "automation-sdk-porttest";
         static string appVers = "1.0";
-        static string host = "eu-qa.dme.mobiledgex.net";
-        static string fallbackDmeHost = "eu-qa.dme.mobiledgex.net";
+        static string host = "us-qa.dme.mobiledgex.net";
+        static string fallbackDmeHost = "us-qa.dme.mobiledgex.net";
 
         //Main
         // Production env

--- a/testcases/csharp/getWEBServerConnectionRest/getWEBServerConnectionRest/getWEBServerConnectionRest.csproj
+++ b/testcases/csharp/getWEBServerConnectionRest/getWEBServerConnectionRest/getWEBServerConnectionRest.csproj
@@ -12,6 +12,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0-rc2" />
+    <PackageReference Include="MobiledgeX.MatchingEngineSDKRestLibrary" Version="3.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
	modified:   testcases/csharp/getConnectionWorkflowRest/getConnectionWorkflowRest/Program.cs
	modified:   testcases/csharp/getConnectionWorkflowRest/getConnectionWorkflowRest/getConnectionWorkflowRest.csproj
	modified:   testcases/csharp/getHTTPConnectionsRest/getHTTPConnectionsRest/Program.cs
	modified:   testcases/csharp/getHTTPConnectionsRest/getHTTPConnectionsRest/getHTTPConnectionsRest.csproj
	modified:   testcases/csharp/getTCPConnectionsRest/getTCPConnectionsRest/Program.cs
	modified:   testcases/csharp/getTCPConnectionsRest/getTCPConnectionsRest/getTCPConnectionsRest.csproj
	modified:   testcases/csharp/getTLSConnectionsRest/getTLSConnectionsRest/Program.cs
	modified:   testcases/csharp/getTLSConnectionsRest/getTLSConnectionsRest/getTLSConnectionsRest.csproj
	modified:   testcases/csharp/getUDPConnectionsRest/getUDPConnectionsRest/Program.cs
	modified:   testcases/csharp/getUDPConnectionsRest/getUDPConnectionsRest/getUDPConnectionsRest.csproj
	modified:   testcases/csharp/getWEBServerConnectionRest/getWEBServerConnectionRest/Program.cs
	modified:   testcases/csharp/getWEBServerConnectionRest/getWEBServerConnectionRest/getWEBServerConnectionRest.csproj