### PR TITLE
Update Podfile for new GRPC depedencies in Swift 5

### DIFF
--- a/testcases/ios/EdgeEventsTestApp/Podfile
+++ b/testcases/ios/EdgeEventsTestApp/Podfile
@@ -4,7 +4,7 @@ platform :ios, '13.0'
 source 'https://github.com/CocoaPods/Specs.git'
 plugin 'cocoapods-art', :sources => ['cocoapods-releases']
 target 'EdgeEventsTestApp'  do
-  pod 'MobiledgeXiOSGrpcLibrary', '= 3.0'
+  pod 'MobiledgeXiOSGrpcLibrary', '= 3.0.5'
 
   target 'EdgeEventsTestAppTests' do
     inherit! :search_paths
@@ -19,10 +19,10 @@ post_install do |installer|
      puts "#{target.name}"
      target.build_configurations.each do |config|
        config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
-       if target.name == "gRPC-Swift" || target.name == "SwiftNIO" || target.name == "SwiftNIOConcurrencyHelpers" || target.name == "SwiftNIOExtras" || target.name == "SwiftNIOFoundationCompat" || target.name == "SwiftNIOHPACK" || target.name == "SwiftNIOHTTP1" || target.name == "SwiftNIOHTTP2" || target.name == "SwiftNIOSSL" || target.name == "SwiftNIOTLS" || target.name == "SwiftNIOTransportServices"
-         config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'NO'
-       end
-     end
-   end
- end
+       if target.name == "gRPC-Swift" || target.name == "_NIODataStructures" || target.name == "SwiftNIO" || target.name == "SwiftNIOCore" || target.name == "SwiftNIOPosix" || target.name == "SwiftNIOEmbedded" ||  target.name == "SwiftNIOConcurrencyHelpers" || target.name == "SwiftNIOExtras" || target.name == "SwiftNIOFoundationCompat" || target.name == "SwiftNIOHPACK" || target.name == "SwiftNIOHTTP1" || target.name == "SwiftNIOHTTP2" || target.name == "SwiftNIOSSL" || target.name == "SwiftNIOTLS" || target.name == "SwiftNIOTransportServices"
+        config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'NO'
+      end
+    end
+  end
+end
 


### PR DESCRIPTION
Updated Podfile for new GRPC MobiledgeXiOSGrpcLibrary version 3.0.5, compiled to min SDK 13.0, Swift 5.5, more Library Evolution exclusions added.

This should fix the library dependency issue for Swift 5.5. Latest for Big Sur, and most developers must move to new MacOS + Xcode versions in order to compile for new iPhones, so backwards compatibility should be a minimal concern.
