### PR TITLE
Adding tests for the failed login timed lockout feature

### DIFF
--- a/testcases/mc/mc_login_failed_timeout.robot
+++ b/testcases/mc/mc_login_failed_timeout.robot
@@ -213,7 +213,7 @@ MC - Veriy failed login set to 0 works
 
 *** Keywords ***
 Setup
-	${adminToken}=   Login  username=qaadmin  password=mexadminfastedgecloudinfra
+	${adminToken}=   Login  username=${admin_manager_username}  password=${admin_manager_password}
 
 	Set Suite Variable    ${adminToken}
 


### PR DESCRIPTION
	new file:   mc/mc_login_failed_timeout.robot