### PR TITLE
Fixed broken testcase ECQ-2967 to also  test EC-6197

### DIFF
--- a/testcases/mcctl/accessCloudlet_cmd_mcctl.robot
+++ b/testcases/mcctl/accessCloudlet_cmd_mcctl.robot
@@ -7,7 +7,7 @@ Library  Collections
 Library  String
 
 
-#Test Teardown  Cleanup Provisioning
+Test Teardown  Cleanup Provisioning
 
 Test Timeout  8m
 


### PR DESCRIPTION
![Screen Shot 2022-03-05 at 12 14 43 AM](https://user-images.githubusercontent.com/63373223/156871250-b171ae44-dd3f-4965-bfc5-5a934b7162c7.png)
